### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Ricky El-Qasem <info@youmakerobots.com>
 maintainer=Ricky El-Qasem <info@youmakerobots.com>
 sentence=Allows You to generate tones regardless of which Arduino
 paragraph=The existing examples of how to generate a tone on arduino varies depending which board you have. MultiBoardTone allows you to choose a function depending which board you have.
-category=tone generator
+category=Signal Input/Output
 url=https://www.youmakerobots.com
 architectures=*


### PR DESCRIPTION
The previous `category` value caused the warning:
```
WARNING: Category 'tone generator' in library MultiBoardTone is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format